### PR TITLE
added missing tab declaration for config

### DIFF
--- a/src/app/code/community/Hevelop/FacebookPixel/etc/system.xml
+++ b/src/app/code/community/Hevelop/FacebookPixel/etc/system.xml
@@ -8,6 +8,12 @@
 */
 -->
 <config>
+    <tabs>
+        <hevelop translate="label" module="hevelop_facebookpixel">
+            <label>Hevelop</label>
+            <sort_order>200</sort_order>
+        </hevelop>
+    </tabs>
     <sections>
         <hevelopfacebookpixel translate="label comment" module="hevelop_facebookpixel">
             <label>Facebook Pixel</label>


### PR DESCRIPTION
system.xml referred to a tab which did not exist and so the configuration was inaccessible from the backend. Declaration has been added
